### PR TITLE
Fix init error in qgis 3.22.1.

### DIFF
--- a/icon_utils.py
+++ b/icon_utils.py
@@ -15,7 +15,7 @@ def create_icon(icon_path, color, base_size=QSize(48, 48)):
     output_pixmap.fill(QColor("transparent"))
     painter = QPainter(output_pixmap)
 
-    ratio = base_size.width() / 48.0
+    ratio = int(base_size.width() / 48.0)
 
     base_icon = QIcon(icon_path)
     base_pixmap = base_icon.pixmap(base_size)
@@ -40,7 +40,7 @@ def select_all_icon(color, base_size=QSize(48, 48)):
     output_pixmap.fill(QColor("transparent"))
     painter = QPainter(output_pixmap)
 
-    ratio = base_size.width() / 48.0
+    ratio = int(base_size.width() / 48.0)
 
     stroke_color = color.darker()
     painter.setRenderHint(QPainter.Antialiasing)
@@ -106,7 +106,7 @@ def expression_select_icon(color, base_size=QSize(48, 48)):
     output_pixmap.fill(QColor("transparent"))
     painter = QPainter(output_pixmap)
 
-    ratio = base_size.width() / 48.0
+    ratio = int(base_size.width() / 48.0)
 
     base_icon = QIcon(":/plugins/multilayerselect/icons/selectExpression.svg")
     base_pixmap = base_icon.pixmap(base_size)

--- a/multilayerselect.py
+++ b/multilayerselect.py
@@ -353,7 +353,8 @@ class MultiLayerSelect:
         """ Called when the selection color has changed. Replace every icon """
         color = self.iface.mapCanvas().selectionColor()
         color = QColor.fromHsv(
-            color.hue(), color.saturation() * 0.9, color.value() * 0.95, color.alpha()
+            int(color.hue()), int(color.saturation() * 0.9),
+            int(color.value() * 0.95), int(color.alpha())
         )
         for i in range(len(self.select_actions)):
             path = self.actions_settings[i].icon


### PR DESCRIPTION
My linux distribution is ArchLinux, after my last update in this week, my qgis about information is below:

QGIS version:              3.22.1-Białowieża
QGIS code branch:      Release 3.22
Qt version:                  5.15.2
Python version:           3.10.0
GDAL/OGR version:    3.3.1
PROJ version:              8.0.1
EPSG database version: v10.018 (2021-04-02)
GEOS version:               3.9.1-CAPI-1.14.2
SQLite version:              3.37.0
PDAL version:                2.3.0
PostgreSQL client version: 13.4
SpatiaLite version:        5.0.1
QWT version:               6.2.0
QScintilla2 version:       2.13.1
system distribution:       Arch Linux

actived Python plugins:
db_manager:       0.1.20
MetaSearch:       0.3.5
processing:       2.12.99
grassprovider:    2.12.99
sagaprovider:     2.12.99
multilayerselect: 1.4.1

and this plugin could not work.
Now I fix this bug, change some code to use int rather than float to invoke some interface, it works fine now.
So I create this pull request, hope you could approve it, thanks~